### PR TITLE
Add CI test to check all configurations

### DIFF
--- a/.github/workflows/test_docker_image.yml
+++ b/.github/workflows/test_docker_image.yml
@@ -33,3 +33,12 @@ jobs:
             --config src/configs/test.json \
             --acs_lib_path $(python3 -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])') \
             --emu_lib_path /apps/build/release/lib/libacs_cb_emu.so
+      
+      - name: Check all configurations
+        run: |
+          . /apps/.venv/bin/activate
+          for cfg in src/configs/*.json; do
+            name="${cfg%.json}"
+            mkdir -p "results/$name"
+            python3 src/main.py --check_config_only --config "$cfg"
+          done

--- a/README.md
+++ b/README.md
@@ -159,10 +159,23 @@ If you want to use podman, please execute `export CONTAINER_ENGINE=podman` befor
 - Test the simulator `analog-cim-sim` manually in docker:
 
     ```bash
-    docker run -it --rm --entrypoint "/bin/bash" cim-e
+    docker run -it --rm --entrypoint "/bin/bash" \
+        -v "$PWD/src:/apps/src" \
+        -v "$PWD/models:/apps/models" \
+        -v "$PWD/results:/apps/results" \
+        cim-e
     source .venv/bin/activate
     python3 -m unittest discover -s analog-cim-sim/int-bindings/test -p '*_test.py'
     deactivate && exit
+    ```
+
+    In case you are using podman, change the first command to:
+    ```bash
+    podman run -it --rm --entrypoint "/bin/bash" \
+        -v "$PWD/src:/apps/src:Z" \
+        -v "$PWD/models:/apps/models:Z" \
+        -v "$PWD/results:/apps/results:Z" \
+        cim-e
     ```
 
 - Debug Python code in VSCode:

--- a/src/main.py
+++ b/src/main.py
@@ -44,6 +44,10 @@ if __name__ == "__main__":
         type=str,
         help='Path to the libacs_cb_emu.so library',
         default=f"{repo_path}/build/release/lib/libacs_cb_emu.so")
+    parser.add_argument(
+        '--check_config_only',
+        action='store_true',
+        help='Only check the config file and do not run the experiment')
     parser.add_argument('--acs_cfg_dir',
                         type=str,
                         help='Path to the ACS config directory',
@@ -58,6 +62,7 @@ if __name__ == "__main__":
     print(f"ACS library path: {args.acs_lib_path}")
     print(f"EMU library path: {args.emu_lib_path}")
     print(f"ACS config directory: {args.acs_cfg_dir}")
+    print(f"Check config only: {args.check_config_only}")
 
     with open(args.config, 'r') as json_file:
         cfg = json.load(json_file)
@@ -65,6 +70,9 @@ if __name__ == "__main__":
     exp_name = args.config.split('/')[-1].split('.json')[0]
 
     exp = create_experiment(cfg)
-    run_experiments(exp, exp_name, args.n_jobs, args.debug,
-                    args.use_same_inputs, args.save_sim_stats,
-                    args.acs_lib_path, args.emu_lib_path, args.acs_cfg_dir)
+    print(f"Valid configuration: {exp_name}")
+
+    if not args.check_config_only:
+        run_experiments(exp, exp_name, args.n_jobs, args.debug,
+                        args.use_same_inputs, args.save_sim_stats,
+                        args.acs_lib_path, args.emu_lib_path, args.acs_cfg_dir)


### PR DESCRIPTION
* Add new argument `--check_config_only` to check only the configuration without starting the experiment.
* Test all configurations in `src/acs_configs` in the CI to ensure compatibility with `ExpConfig`.
* Improve documentation for debugging purposes.